### PR TITLE
Highlight the importance of having ngOnDestroy defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ export class InboxComponent {
       .subscribe(val => console.log(val))
   }
 
+  // This method must be present, even if empty! 
+  // Otherwise 'ng build --prod' will optimize away any calls to ngOnDestroy, 
+  // even if the method is added by the @TakeUntilDestroy decorator
   ngOnDestroy() {
     // You can also do whatever you need here
   }


### PR DESCRIPTION
Found this after a long debugging session of minified prod files.
If at compile time ngOnDestroy is missing, the generated code will use a byte mask that never triggeres the ngOnDestroy call, even if the function actually exists at runtime ...

```
// inside main.js
// this is part of the component definition if ngOnDestroy is missing
r._31(638976, ...)
// this is when ngOnDestroy is present
r._31(770048, ...)

// inside vendor.js
function callProviderLifecycles(view, index, lifecycles) {
     ...
    if (lifecycles & 131072 /* OnDestroy */) {
        provider.ngOnDestroy();
    }
}


```
